### PR TITLE
[IntfsOrch] Fix VRF update handling for loopback interfaces

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -846,6 +846,19 @@ void IntfsOrch::doTask(Consumer &consumer)
                         m_syncdIntfses[alias] = intfs_entry;
                         m_vrfOrch->increaseVrfRefCount(vrf_id);
                     }
+                    else if (m_syncdIntfses[alias].vrf_id != vrf_id)
+                    {
+                        if (m_syncdIntfses[alias].ip_addresses.size() == 0)
+                        {
+                            m_vrfOrch->decreaseVrfRefCount(m_syncdIntfses[alias].vrf_id);
+                            m_vrfOrch->increaseVrfRefCount(vrf_id);
+                            m_syncdIntfses[alias].vrf_id = vrf_id;
+                        }
+                        else
+                        {
+                            SWSS_LOG_ERROR("Failed to set interface '%s' to VRF ID '%d' because it has IP addresses associated with it.", alias.c_str(), vrf_id);
+                        }
+                    }
                 }
                 else
                 {

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -330,5 +330,63 @@ namespace intfsorch_test
         static_cast<Orch *>(gIntfsOrch)->doTask();
         ASSERT_EQ(current_create_count + 1, create_rif_count);
         ASSERT_EQ(current_remove_count + 1, remove_rif_count);
+    };
+
+    TEST_F(IntfsOrchTest, IntfsOrchVrfUpdate)
+    {
+        //create a new vrf
+        std::deque<KeyOpFieldsValuesTuple> entries;
+        entries.push_back({"Vrf-Blue", "SET", { {"NULL", "NULL"}}});
+        auto consumer = dynamic_cast<Consumer *>(gVrfOrch->getExecutor(APP_VRF_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gVrfOrch)->doTask(); 
+        ASSERT_TRUE(gVrfOrch->isVRFexists("Vrf-Blue"));
+        auto new_vrf_reference_count = gVrfOrch->getVrfRefCount("Vrf-Blue");
+        ASSERT_EQ(new_vrf_reference_count, 0);
+
+        // create an interface
+        entries.clear();
+        entries.push_back({"Loopback2", "SET", {}});
+        consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+        IntfsTable m_syncdIntfses = gIntfsOrch->getSyncdIntfses();
+        ASSERT_EQ(m_syncdIntfses["Loopback2"].vrf_id, gVirtualRouterId);
+
+        // change vrf and check if it worked
+        entries.clear();
+        entries.push_back({"Loopback2", "SET", { {"vrf_name", "Vrf-Blue"}}});
+        consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+        auto new_vrf_updated_reference_count = gVrfOrch->getVrfRefCount("Vrf-Blue");
+        ASSERT_EQ(new_vrf_reference_count + 1, new_vrf_updated_reference_count);
+        m_syncdIntfses = gIntfsOrch->getSyncdIntfses();
+        ASSERT_EQ(m_syncdIntfses["Loopback2"].vrf_id, gVrfOrch->getVRFid("Vrf-Blue"));
+
+        // create an interface
+        entries.clear();
+        entries.push_back({"Loopback3", "SET", {}});
+        consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+        m_syncdIntfses = gIntfsOrch->getSyncdIntfses();
+        ASSERT_EQ(m_syncdIntfses["Loopback3"].vrf_id, gVirtualRouterId);
+
+        // Add IP address to the interface
+        entries.clear();
+        entries.push_back({"Loopback3:3.3.3.3/32", "SET", {{"scope", "global"},{"family", "IPv4"}}});
+        consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+
+        // change vrf and check it doesn't affect the interface due to existing IP
+        entries.clear();
+        entries.push_back({"Loopback3", "SET", { {"vrf_name", "Vrf-Blue"}}});
+        consumer = dynamic_cast<Consumer *>(gIntfsOrch->getExecutor(APP_INTF_TABLE_NAME));
+        consumer->addToSync(entries);
+        static_cast<Orch *>(gIntfsOrch)->doTask();
+        m_syncdIntfses = gIntfsOrch->getSyncdIntfses();
+        ASSERT_EQ(m_syncdIntfses["Loopback3"].vrf_id, gVirtualRouterId);    
     }
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Addressed the scenario where an interface exists in m_syncdIntfses, but the incoming VRF does not match the updated VRF for the loopback interface. The solution involves updating the loopback’s VRF ID, decrementing the reference count for the old VRF, and incrementing the reference count for the new VRF

**Why I did it**

Sometimes, when a loopback interface is added to a non-default VRF, an ip2me route is incorrectly added to the default VRF. This issue occurs because the Intfsorch is not handling the case where the interface exists in m_syncdIntfses, but the VRF does not match the updated VRF configuration.

**How I verified it**

Reproduced the issue with the fix applied and verified in the SAI Redis log that the ip2me route was correctly added to the non-default VRF

2025-01-07.20:48:12.797119|c|SAI_OBJECT_TYPE_ROUTE_ENTRY:{"dest":"8.8.8.8/32","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000427"}|SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION=SAI_PACKET_ACTION_FORWARD|SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID=oid:0x1000000000001

Added Unit Tests


**Details if related**
